### PR TITLE
Adjusts outcome proportion margin location in the CSS for consistency

### DIFF
--- a/src/SupervisionSuccess/components/Outcomes/Outcomes.scss
+++ b/src/SupervisionSuccess/components/Outcomes/Outcomes.scss
@@ -51,6 +51,7 @@
     }
     @media (max-width: $md) {
       padding-left: 1rem;
+      margin-bottom: 3rem;
     }
   }
 
@@ -86,7 +87,6 @@
   &_stat-proportion {
     margin-top: 0.25rem;
     @media (max-width: $md) {
-      margin-bottom: 3rem;
       margin-top: 0;
     }
   }


### PR DESCRIPTION
## Description of the change

After the most recent PR, there was a margin inconsistency between mobile and desktop. If there are two lines of outcome proportion text, then in mobile we had a margin producing space between the two lines, whereas in desktop the two lines were vertically adjacent. This makes it so that we don't have that margin regardless, while maintaining the margin between the outcomes proportions and the next section in the UI (the chart).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Follow-up to #82 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
