### PR TITLE
More dependency updates to avoid vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react-app-polyfill": "^1.0.6",
     "react-chartjs-2": "^2.10.0",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.4",
     "react-select": "^3.1.0",
     "react-slider": "^1.0.9",
     "react-spinners": "^0.9.0",
@@ -35,6 +34,7 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.4.0",
     "prettier": "^2.1.2",
+    "react-scripts": "3.4.4",
     "react-test-renderer": "^16.13.1",
     "sass": "^1.49.8"
   },
@@ -81,6 +81,7 @@
     "nth-check": "^2.0.1",
     "object-path": "^0.11.6",
     "eslint-plugin-import": "2.22.1",
+    "selfsigned": "1.10.13",
     "**/glob-parent": "^5.1.2",
     "**/normalize-url": "^4.5.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7687,10 +7687,10 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -10025,12 +10025,12 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.7:
-  version "1.10.14"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.14.tgz#ee51d84d9dcecc61e07e4aba34f229ab525c1574"
-  integrity sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==
+selfsigned@1.10.13, selfsigned@^1.10.7:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.13.tgz#763e091c684cbcbe98aa40b15b01da3716d68a12"
+  integrity sha512-UmLwTKZwNmXYDAlRFhaEdgEg0dp9k5gfJXuO7uKvSqioN1M0+Mgf4V39IlVZMSuqGoCi6h5legkhNXvWy0rFSg==
   dependencies:
-    node-forge "^0.10.0"
+    node-forge "^1.2.0"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description of the change

Two things happening here:
- Downgrades selfsigned from 1.10.14 to 1.10.13 via resolution because for some reason their upgrade of node-forge is only in the latter and not the former, and there's no other change in the former that is interesting to us. This resolves the three node-forge vulnerabilities
- Moves react-scripts from dependencies to dev-dependencies, [where it belongs](https://github.com/facebook/create-react-app/issues/11174), and where it should hopefully no longer trigger transitive dependency vulnerabilities, assuming Github is using the `--production` flag on its npm audits. This resolve all remaining dependency vulnerabilities, all of which are transitive dependencies from react-scripts

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #162 
Closes #163 
Closes #165
Closes #166 
Closes #174 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
